### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -165,6 +165,8 @@ jobs:
 
   run_linter:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/dgraciac/david-gracia-website/security/code-scanning/1](https://github.com/dgraciac/david-gracia-website/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow or the specific job (`run_linter`) to explicitly define the required permissions for the `GITHUB_TOKEN`. Since the job only performs linting operations, it requires read-only access to the repository contents. The `permissions` block should be added at the job level to limit the scope of permissions to this specific job.

Steps to implement the fix:
1. Add a `permissions` block under the `run_linter` job.
2. Set `contents: read` to grant read-only access to the repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
