### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/on-pull-request.yaml
+++ b/.github/workflows/on-pull-request.yaml
@@ -183,6 +183,8 @@ jobs:
 
   build_application:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/dgraciac/david-gracia-website/security/code-scanning/2](https://github.com/dgraciac/david-gracia-website/security/code-scanning/2)

To fix the issue, add a `permissions` block to the `build_application` job. Since the job only involves reading repository contents and does not require write access, the permissions should be limited to `contents: read`. This ensures the job has the minimum privileges necessary to complete its tasks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
